### PR TITLE
Bug 1 to string undefined error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # winston-groonga
 A Winston transport for Groonga Database
 
-v 1.1.1 - 06/23/2016
+v 1.1.2 - 06/29/2016
 
 ## Installation
 

--- a/lib/winston-groonga.js
+++ b/lib/winston-groonga.js
@@ -102,7 +102,7 @@ buildLogString = function (params) {
         _key: logMsgUID.toString()
     };
     _.forEach(params, function (n, key) {
-        q[0][key] = n.toString();
+        q[0][key] = n && n.toString() || "";
     });
     return q;
 }
@@ -158,3 +158,7 @@ createPath = function (groonga) {
         }
     }
 };
+
+process.on("uncaughtException", function (error) {
+    console.log("winston-groonga uncaught exception: " + error);
+});


### PR DESCRIPTION
Adds in a makes sure the object value exists before doing .toString() on it. If it does not exist default to blank string. Also added in if an uncaught exception occurs console log that winston-groonga made the error.
